### PR TITLE
Add static website and Strapi recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
 # Website
+
+这个项目包含一个简单的静态前端示例，并推荐使用 **Strapi** 作为后端。
+
+## 前端
+
+`frontend/` 目录下存放静态页面，可直接在浏览器中打开 `index.html` 预览效果。页面展示了图片画廊和从后端获取的文章列表（请求地址需根据实际部署的 Strapi 实例进行修改）。
+
+## 推荐的后端：Strapi
+
+- 仓库地址：<https://github.com/strapi/strapi>
+- 运行环境：Node.js
+- 主要优势：支持内容管理、文件上传、REST 与 GraphQL API，社区活跃。
+
+### 快速开始
+1. 全局安装 `yarn`：`npm install -g yarn`
+2. 克隆仓库并安装依赖：
+   ```bash
+   git clone https://github.com/strapi/strapi.git
+   cd strapi
+   yarn install
+   ```
+3. 运行示例项目：
+   ```bash
+   yarn build --clean
+   yarn develop
+   ```
+4. 根据 Strapi 文档创建 `Post` 内容类型，启用公开读取权限，随后在 `frontend/script.js` 中将 `fetch` 地址改为实际接口地址。
+
+更多配置及部署方式请参考 [Strapi 官方文档](https://docs.strapi.io/)。

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>个人博客</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <h1>欢迎来到我的博客</h1>
+  </header>
+  <section id="gallery">
+    <h2>图片展示</h2>
+    <div class="images">
+      <img src="https://source.unsplash.com/random/300x200?sig=1" alt="示例图片1" />
+      <img src="https://source.unsplash.com/random/300x200?sig=2" alt="示例图片2" />
+      <img src="https://source.unsplash.com/random/300x200?sig=3" alt="示例图片3" />
+    </div>
+  </section>
+  <section id="posts">
+    <h2>文章列表</h2>
+    <ul></ul>
+  </section>
+  <footer>
+    <p>&copy; 2024 我的博客</p>
+  </footer>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', () => {
+  fetch('https://cms.example.com/api/posts')
+    .then((res) => res.json())
+    .then((data) => {
+      const list = document.querySelector('#posts ul');
+      data.forEach((post) => {
+        const li = document.createElement('li');
+        li.textContent = post.title;
+        list.appendChild(li);
+      });
+    })
+    .catch((err) => {
+      console.error('获取文章失败:', err);
+    });
+});

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,0 +1,40 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  background-color: #f4f4f4;
+}
+header {
+  background-color: #333;
+  color: #fff;
+  padding: 1rem;
+  text-align: center;
+}
+#gallery {
+  padding: 1rem;
+  text-align: center;
+}
+#gallery .images {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+}
+#gallery img {
+  width: 300px;
+  height: 200px;
+  object-fit: cover;
+  border-radius: 8px;
+}
+#posts {
+  padding: 1rem;
+  max-width: 600px;
+  margin: 0 auto;
+}
+footer {
+  background-color: #333;
+  color: #fff;
+  text-align: center;
+  padding: 1rem;
+  margin-top: 2rem;
+}


### PR DESCRIPTION
## Summary
- create a simple static frontend in `frontend/`
- recommend using Strapi as the backend
- update README with setup steps and links

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68654c560390832f9787198c9540cbda