### PR TITLE
Add Strapi backend setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
 # Website
+
+这个项目包含一个简单的静态前端示例，并推荐使用 **Strapi** 作为后端。项目根目录下的
+`backend/` 提供了通过 Docker 快速启动 Strapi 的配置。
+
+## 前端
+
+`frontend/` 目录下存放静态页面，可直接在浏览器中打开 `index.html` 预览效果。页面展示了图片画廊和从后端获取的文章列表（请求地址需根据实际部署的 Strapi 实例进行修改）。
+
+## 推荐的后端：Strapi
+
+- 仓库地址：<https://github.com/strapi/strapi>
+- 运行环境：Node.js
+- 主要优势：支持内容管理、文件上传、REST 与 GraphQL API，社区活跃。
+
+### 快速开始
+1. 全局安装 `yarn`：`npm install -g yarn`
+2. 克隆仓库并安装依赖：
+   ```bash
+   git clone https://github.com/strapi/strapi.git
+   cd strapi
+   yarn install
+   ```
+3. 运行示例项目：
+   ```bash
+   yarn build --clean
+   yarn develop
+   ```
+4. 根据 Strapi 文档创建 `Post` 内容类型，启用公开读取权限，随后在 `frontend/script.js` 中将 `fetch` 地址改为实际接口地址。
+
+更多配置及部署方式请参考 [Strapi 官方文档](https://docs.strapi.io/)。
+
+### 使用仓库提供的 Docker 配置
+
+在 `backend/` 目录下准备了 `docker-compose.yml`，可以更便捷地启动 Strapi：
+
+1. 进入该目录并执行 `docker-compose up`
+2. 打开 <http://localhost:1337/admin> 创建管理员账户
+3. 使用内容类型构建器（Content-Type Builder）创建 `post` 类型，并开放读取权限
+4. 前端脚本默认请求 `http://localhost:1337/api/posts`

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,11 @@
+# Strapi Backend
+
+该目录提供通过 Docker 运行 [Strapi](https://github.com/strapi/strapi) 的示例配置。
+
+## 使用方法
+
+1. 安装好 Docker 与 docker-compose。
+2. 在此目录下执行 `docker-compose up` 启动服务。
+3. 首次启动后，访问 <http://localhost:1337/admin> 创建管理员账户。
+4. 在管理后台中使用 Content-Type Builder 新建 `post` 集合类型，包含 `title`(文本)、`content`(富文本) 和 `image`(媒体) 字段，并在权限设置中开放公共读取权限。
+5. 完成后，文章接口将位于 <http://localhost:1337/api/posts>。

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+services:
+  strapi:
+    image: strapi/strapi
+    ports:
+      - '1337:1337'
+    environment:
+      DATABASE_CLIENT: sqlite
+      DATABASE_FILENAME: /data/data.db
+    volumes:
+      - ./app:/srv/app
+      - ./data:/data

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>个人博客</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <h1>欢迎来到我的博客</h1>
+  </header>
+  <section id="gallery">
+    <h2>图片展示</h2>
+    <div class="images">
+      <img src="https://source.unsplash.com/random/300x200?sig=1" alt="示例图片1" />
+      <img src="https://source.unsplash.com/random/300x200?sig=2" alt="示例图片2" />
+      <img src="https://source.unsplash.com/random/300x200?sig=3" alt="示例图片3" />
+    </div>
+  </section>
+  <section id="posts">
+    <h2>文章列表</h2>
+    <ul></ul>
+  </section>
+  <footer>
+    <p>&copy; 2024 我的博客</p>
+  </footer>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', () => {
+  fetch('http://localhost:1337/api/posts')
+    .then((res) => res.json())
+    .then((data) => {
+      const list = document.querySelector('#posts ul');
+      data.forEach((post) => {
+        const li = document.createElement('li');
+        li.textContent = post.title;
+        list.appendChild(li);
+      });
+    })
+    .catch((err) => {
+      console.error('获取文章失败:', err);
+    });
+});

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,0 +1,40 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  background-color: #f4f4f4;
+}
+header {
+  background-color: #333;
+  color: #fff;
+  padding: 1rem;
+  text-align: center;
+}
+#gallery {
+  padding: 1rem;
+  text-align: center;
+}
+#gallery .images {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+}
+#gallery img {
+  width: 300px;
+  height: 200px;
+  object-fit: cover;
+  border-radius: 8px;
+}
+#posts {
+  padding: 1rem;
+  max-width: 600px;
+  margin: 0 auto;
+}
+footer {
+  background-color: #333;
+  color: #fff;
+  text-align: center;
+  padding: 1rem;
+  margin-top: 2rem;
+}


### PR DESCRIPTION
## Summary
- configure Docker-based Strapi backend under `backend/`
- document quick Docker setup in the root README
- update frontend to fetch posts from local Strapi API

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68654c560390832f9787198c9540cbda