### PR TITLE
Fix missing fetch call in script.js

### DIFF
--- a/frontend/script.js
+++ b/frontend/script.js
@@ -1,5 +1,5 @@
 document.addEventListener('DOMContentLoaded', () => {
-
+  fetch('http://localhost:1337/api/posts')
     .then((res) => res.json())
     .then((data) => {
       const list = document.querySelector('#posts ul');


### PR DESCRIPTION
## Summary
- ensure the frontend fetches posts properly by adding a missing `fetch` call

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_686550738558832fbdbb43f77666b268