### PR TITLE
Add basic node server and tests

### DIFF
--- a/frontend/script.js
+++ b/frontend/script.js
@@ -3,9 +3,10 @@ document.addEventListener('DOMContentLoaded', () => {
     .then((res) => res.json())
     .then((data) => {
       const list = document.querySelector('#posts ul');
-      data.forEach((post) => {
+      data.data.forEach((entry) => {
+        const { title } = entry.attributes;
         const li = document.createElement('li');
-        li.textContent = post.title;
+        li.textContent = title;
         list.appendChild(li);
       });
     })

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "type": "module",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node test.js"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,32 @@
+import http from 'http';
+import { createReadStream, existsSync } from 'fs';
+import { extname, join } from 'path';
+
+const port = process.env.PORT || 3000;
+const root = new URL('./frontend/', import.meta.url).pathname;
+
+const mimeTypes = {
+  '.html': 'text/html',
+  '.js': 'text/javascript',
+  '.css': 'text/css',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif'
+};
+
+const server = http.createServer((req, res) => {
+  const filePath = join(root, req.url === '/' ? 'index.html' : req.url);
+  if (!existsSync(filePath)) {
+    res.statusCode = 404;
+    res.end('Not found');
+    return;
+  }
+  const ext = extname(filePath);
+  res.setHeader('Content-Type', mimeTypes[ext] || 'text/plain');
+  createReadStream(filePath).pipe(res);
+});
+
+server.listen(port, () => {
+  console.log(`Server running on http://localhost:${port}`);
+});

--- a/test.js
+++ b/test.js
@@ -1,0 +1,6 @@
+import fs from 'fs';
+import assert from 'assert';
+
+const script = fs.readFileSync('./frontend/script.js', 'utf8');
+assert(script.includes('fetch('), 'fetch call missing in script.js');
+console.log('All tests passed');


### PR DESCRIPTION
## Summary
- update frontend fetch call for Strapi API response
- add Node.js static server
- add `package.json` with start and test scripts
- add simple test to check fetch usage

## Testing
- `node test.js`


------
https://chatgpt.com/codex/tasks/task_e_686554e8b230832f86f21976d8c11e63