### PR TITLE
Add nginx reverse proxy config

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,24 @@
 
 更多配置及部署方式请参考 [Strapi 官方文档](https://docs.strapi.io/)。
 
+## Nginx 反向代理示例
+
+部署到线上环境时，可使用 Nginx 提供静态文件并将 `/api` 路径转发至 Strapi。
+`nginx/site.conf` 给出了一个示例配置，核心部分如下：
+
+```nginx
+server {
+    listen 80;
+    server_name example.com;
+
+    root /var/www/website/frontend;
+    index index.html;
+
+    location /api/ {
+        proxy_pass http://localhost:1337/;
+    }
+}
+```
+
+将 `root` 与 `server_name` 根据实际服务器调整，启用后即可通过同一域名访问前端页面并由 `/api` 转发请求到 Strapi 后端。
+

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -1,5 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
-  fetch('http://localhost:1337/api/posts')
+  // 请求同域名下的 Strapi 接口，可通过 nginx 转发到实际后端
+  fetch('/api/posts')
     .then((res) => res.json())
     .then((data) => {
       const list = document.querySelector('#posts ul');

--- a/nginx/site.conf
+++ b/nginx/site.conf
@@ -1,0 +1,21 @@
+server {
+    listen 80;
+    server_name example.com;
+
+    # 静态文件根目录，根据实际部署路径调整
+    root /var/www/website/frontend;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ =404;
+    }
+
+    # 代理 API 请求到 Strapi 后端
+    location /api/ {
+        proxy_pass http://localhost:1337/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
## Summary
- fetch posts using relative URL
- provide nginx reverse proxy configuration and doc

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865fb54ae50832fb32ec607bd5147ab