### PR TITLE
Add backend npm script and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,13 @@
    ```
 4. 根据 Strapi 文档创建 `Post` 内容类型，启用公开读取权限，随后在 `frontend/script.js` 中将 `fetch` 地址改为实际接口地址。
 
+如果你希望直接在本仓库中通过 Docker 快速启动 Strapi，可执行：
+
+```bash
+npm run backend
+```
+
+该命令会使用 `backend/docker-compose.yml` 配置并在本地启动服务。
+
 更多配置及部署方式请参考 [Strapi 官方文档](https://docs.strapi.io/)。
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "type": "module",
   "scripts": {
     "start": "node server.js",
-    "test": "node test.js"
+    "test": "node test.js",
+    "backend": "docker-compose -f backend/docker-compose.yml up"
   }
 }


### PR DESCRIPTION
## Summary
- add `backend` script to run Strapi via docker-compose
- document new command in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68661d1089e4832fae5f4d2fed29a425