### PR TITLE
Add configurable API base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,15 @@
 
 ## 前端
 
-`frontend/` 目录下存放静态页面，可直接在浏览器中打开 `index.html` 预览效果。页面展示了图片画廊和从后端获取的文章列表（请求地址需根据实际部署的 Strapi 实例进行修改）。
+`frontend/` 目录下存放静态页面，可直接在浏览器中打开 `index.html` 预览效果。页面展示了图片画廊和从后端获取的文章列表。
+
+## 配置
+
+前端使用 `frontend/config.js` 提供可配置的 API 基础地址。你可以在加载脚本前设置
+`window.CONFIG = { API_BASE_URL: 'http://your-server:1337' }`，或在运行环境中设置
+`API_BASE_URL` 变量。未配置时默认使用 `http://localhost:1337`。
+
+`index.html` 已在引入 `script.js` 前加载 `config.js`，脚本会读取该地址来请求文章数据。
 
 ## 推荐的后端：Strapi
 

--- a/frontend/config.js
+++ b/frontend/config.js
@@ -1,0 +1,12 @@
+(() => {
+  const baseUrl =
+    (typeof window !== 'undefined' && window.CONFIG && window.CONFIG.API_BASE_URL) ||
+    (typeof process !== 'undefined' && process.env && process.env.API_BASE_URL) ||
+    'http://localhost:1337';
+  if (typeof window !== 'undefined') {
+    window.API_BASE_URL = baseUrl;
+  }
+  if (typeof module !== 'undefined') {
+    module.exports = { API_BASE_URL: baseUrl };
+  }
+})();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -25,6 +25,7 @@
   <footer>
     <p>&copy; 2024 我的博客</p>
   </footer>
+  <script src="config.js"></script>
   <script src="script.js"></script>
 </body>
 </html>

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -1,5 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
-  fetch('http://localhost:1337/api/posts')
+  const base = window.API_BASE_URL || 'http://localhost:1337';
+  fetch(`${base}/api/posts`)
     .then((res) => res.json())
     .then((data) => {
       const list = document.querySelector('#posts ul');


### PR DESCRIPTION
## Summary
- allow customizing API base URL via `frontend/config.js`
- load `config.js` before the main script in `index.html`
- fetch posts using the configurable base URL
- document configuration usage in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68661d106f18832fb4888cb81120aa9e