### PR TITLE
Add Docker Compose for frontend reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,15 @@
    ```
 4. 根据 Strapi 文档创建 `Post` 内容类型，启用公开读取权限，随后在 `frontend/script.js` 中将 `fetch` 地址改为实际接口地址。
 
-如果你希望直接在本仓库中通过 Docker 快速启动 Strapi，可执行：
+如果你希望通过 Docker 同时启动前端与后端，可在仓库根目录执行：
+
+```bash
+docker-compose up
+```
+
+此命令会使用 `docker-compose.yml` 运行 Nginx 与 Strapi，前端将通过 <http://localhost:3000> 提供，后台仍在 <http://localhost:1337>。
+
+若只想启动 Strapi 后端，可执行：
 
 ```bash
 npm run backend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3'
+services:
+  frontend:
+    image: nginx:alpine
+    ports:
+      - '3000:80'
+    volumes:
+      - ./frontend:/usr/share/nginx/html:ro
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - backend
+  backend:
+    image: strapi/strapi
+    ports:
+      - '1337:1337'
+    environment:
+      DATABASE_CLIENT: sqlite
+      DATABASE_FILENAME: /data/data.db
+    volumes:
+      - ./backend/app:/srv/app
+      - ./backend/data:/data

--- a/frontend/config.js
+++ b/frontend/config.js
@@ -2,7 +2,7 @@
   const baseUrl =
     (typeof window !== 'undefined' && window.CONFIG && window.CONFIG.API_BASE_URL) ||
     (typeof process !== 'undefined' && process.env && process.env.API_BASE_URL) ||
-    'http://localhost:1337';
+    (typeof window !== 'undefined' ? window.location.origin : 'http://localhost:1337');
   if (typeof window !== 'undefined') {
     window.API_BASE_URL = baseUrl;
   }

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,21 @@
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ =404;
+    }
+
+    location /api/ {
+        proxy_pass http://backend:1337/api/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    location /admin/ {
+        proxy_pass http://backend:1337/admin/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}


### PR DESCRIPTION
## Summary
- serve the frontend using nginx and proxy API routes to Strapi
- configure API base URL to default to same origin
- document how to start services with docker-compose

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866232721bc832f9402a55c2fa595af