### PR TITLE
Fix frontend api base url

### DIFF
--- a/frontend/config.js
+++ b/frontend/config.js
@@ -2,7 +2,7 @@
   const baseUrl =
     (typeof window !== 'undefined' && window.CONFIG && window.CONFIG.API_BASE_URL) ||
     (typeof process !== 'undefined' && process.env && process.env.API_BASE_URL) ||
-    (typeof window !== 'undefined' ? window.location.origin : 'http://localhost:1337');
+    'http://localhost:1337';
   if (typeof window !== 'undefined') {
     window.API_BASE_URL = baseUrl;
   }


### PR DESCRIPTION
## Summary
- default API_BASE_URL now points to `http://localhost:1337`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68663c3bb0d8832faccdef0c01f9b9ec